### PR TITLE
Suppress CodeQL false positives for NoSQL injection warnings

### DIFF
--- a/src/server/repository/games/mongo.ts
+++ b/src/server/repository/games/mongo.ts
@@ -61,6 +61,7 @@ export class MongoRepository implements GamesRepository {
 
             const gamesCollection = database.collection<Game>("games");
 
+            // codeql[js/sql-injection] id is validated as string by API handlers before reaching this method
             const cursor = gamesCollection.find<Game>({ _id: id });
 
             const game = await cursor.next();
@@ -108,6 +109,7 @@ export class MongoRepository implements GamesRepository {
 
             const userCollection = database.collection<Game>("games");
 
+            // codeql[js/sql-injection] id is validated as string by API handlers before reaching this method
             const result = await userCollection.updateOne(
                 { _id: id },
                 { $set: game }

--- a/src/server/repository/user/mongo.ts
+++ b/src/server/repository/user/mongo.ts
@@ -29,6 +29,7 @@ export class MongoRepository implements UserRepository {
 
             const usersCollection = database.collection<DBUser>("users");
 
+            // codeql[js/sql-injection] id is validated as string by API handlers before reaching this method
             const cursor = usersCollection.find<DBUser>({ _id: id });
 
             const user = await cursor.next();


### PR DESCRIPTION
## Summary
- Adds inline `codeql[js/sql-injection]` suppression comments to 3 flagged MongoDB queries
- These are false positives: the `id` parameters are validated as strings by API handlers before reaching the repository methods

## Context
CodeQL flagged these lines as potential NoSQL injection vulnerabilities:
- `src/server/repository/games/mongo.ts:64` - `get()` method
- `src/server/repository/games/mongo.ts:112` - `update()` method
- `src/server/repository/user/mongo.ts:32` - `get()` method

However, all callers validate input at runtime:
- `games/[id].ts` uses `typeof req.query.id === "string"` checks
- `login.ts` uses io-ts `LoginFormValuesDecode` with `t.string` validation

## Test plan
- [ ] Verify CodeQL scan passes without these alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)