### PR TITLE
Group Dependabot updates: jest, react, fontawesome

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,26 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+      groups:
+          jest:
+              patterns:
+                  - "jest"
+                  - "jest-*"
+                  - "@jest/*"
+                  - "@types/jest"
+                  - "babel-jest"
+                  - "@testing-library/jest-dom"
+          react:
+              patterns:
+                  - "react"
+                  - "react-dom"
+                  - "react-test-renderer"
+                  - "@types/react"
+                  - "@types/react-dom"
+                  - "@types/react-test-renderer"
+          fontawesome:
+              patterns:
+                  - "@fortawesome/*"
 
     # Enable version updates for github actions
     - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Groups jest ecosystem packages (`jest`, `jest-*`, `@jest/*`, `@types/jest`, `babel-jest`, `@testing-library/jest-dom`) into a single weekly PR
- Groups React core packages (`react`, `react-dom`, `react-test-renderer`, and their `@types/*`) into a single weekly PR
- Groups `@fortawesome/*` packages into a single weekly PR

## Why
The current setup bumps each package independently, which produces broken combinations when packages in a family expect lockstep versions. Concrete example from #1015: bumping `jest` 30.2.0 → 30.4.2 without also bumping `jest-environment-jsdom` left the jsdom env's `moduleMocker` missing `clearMocksOnScope`, and jest-runtime 30.4.x crashes calling it.

Grouping these families means Dependabot opens one PR per family per week with all related packages moving together — fixing both the immediate jest break and the same class of problem for React and Fontawesome.

`react-markdown`, `react-transition-group`, and other third-party `react-*` packages are intentionally excluded — they version independently of React core.

## Test plan
- [ ] Merge and wait for the next weekly Dependabot run to confirm groups produce single PRs
- [ ] Recreate #1015 (`@dependabot recreate` after this lands) so it includes `jest-environment-jsdom` and turns CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)