### PR TITLE
Enable strict-peer-deps in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-peer-deps=true


### PR DESCRIPTION
Fails installs on peer-dep mismatches instead of warning. Catches the class of bug where related packages (jest + jest-environment-jsdom, react + @types/react, etc.) drift apart and produce runtime errors that pass `npm ci` but break tests.