### PR TITLE
Enable strict-peer-deps in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-peer-deps=true


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `strict-peer-deps=true` so `npm install` / `npm ci` fails on peer-dep mismatches instead of warning

## Why
Complements the Dependabot grouping change (#1019). Even with groups configured, a peer-dep drift could slip in (e.g. a manual `package.json` edit). With strict mode on, CI catches it at install time rather than at runtime when tests blow up — same class of failure that gave us #1015.

Verified `npm install --dry-run` resolves cleanly on the current tree, so this doesn't surface any existing mismatches.

## Test plan
- [ ] CI passes on this branch (validates the current dep tree under strict mode)
- [ ] Next Dependabot grouped PR also passes — confirms the setting plays nicely with weekly bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)